### PR TITLE
Deprecate `actions-sbt-release` in favour of `gha-scala-library-release-workflow`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-# GitHub Action to run SBT release
+## This Action is deprecated, see [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
+
+[**`gha-scala-library-release-workflow`**](https://github.com/guardian/gha-scala-library-release-workflow)
+is the recommended alternative to `guardian/actions-sbt-release`.
+
+As a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview),
+rather than a GitHub Action, it's able to isolate release phases in
+[jobs](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow),
+providing better [release credential security](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/security-design.md).
+
+See these PRs as examples of how to switch from `guardian/actions-sbt-release` to `gha-scala-library-release-workflow`:
+
+* https://github.com/guardian/fezziwig/pull/45
+* https://github.com/guardian/atom-maker/pull/93
+
+#### GitHub Action to run SBT release
 
 Use this to run SBT release process.
 


### PR DESCRIPTION
As a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview), rather than a GitHub Action, [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) is able to isolate release phases in GHA [jobs](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow), providing better [release credential security](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/security-design.md). Now that https://github.com/guardian/gha-scala-library-release-workflow/pull/19 means the workflow can do 'preview' style releases, I think it's able to take over most use cases of `actions-sbt-release`.

Hope the wording here is ok - I think once https://github.com/guardian/fezziwig/pull/45 & https://github.com/guardian/atom-maker/pull/93 are merged we should be okay to archive this repo?